### PR TITLE
Updated source for most recent version of Framer

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,11 @@
 		}
 
 		</style>
-
-		<script src="node_modules/framerjs-prebuilt/framer.js"></script>
+		<!---Old Framer Library (included in node_modules)-->
+		<!---<script src="node_modules/framerjs-prebuilt/framer.js"></script>-->
+		
+		<!--Latest version of Framer Library (As of 02-21-2018).  Includes new devices like iPhone 8/8 Plus, iPhone X etc-->
+		<script src = "//builds.framerjs.com/version/latest/framer.js"></script>
 		<script src="app.js"></script>
 
 	</head>


### PR DESCRIPTION
# Now With The Latest Version Of Framer

This branch contains a more up-to-date version of the Framer library.  The original framerjs-prebuilt script is replaced in index.html (only commented out–it's still in the node_modules folder).  The replacement allows for prototyping in new devices such as iPhone 8/8 Plus, iPhone X, Google Pixel 2 etc.

## iPhone X
<img width="557" alt="screen shot 2018-02-21 at 9 55 41 pm" src="https://user-images.githubusercontent.com/19320205/36522538-00bc598c-1752-11e8-83d2-45f880ff4346.png">

## iPhone 8
<img width="558" alt="screen shot 2018-02-21 at 9 58 33 pm" src="https://user-images.githubusercontent.com/19320205/36522607-6b765796-1752-11e8-8cff-a3b4644e6165.png">

## Google Pixel 2 Kinda Blue
<img width="598" alt="screen shot 2018-02-21 at 10 03 18 pm" src="https://user-images.githubusercontent.com/19320205/36522731-1d6f67da-1753-11e8-9dee-d32719adc32b.png">


